### PR TITLE
deconflict -h, move help to -H

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ __Running the starter code:__
 
 To get commandline help, run the command:
 
-    ./bin/convlayer -h
+    ./bin/convlayer --help
 
 To run your scheduled conv layer try:
 

--- a/src/convlayer_main.cpp
+++ b/src/convlayer_main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
   int f_h = 3;
 
   args::ArgumentParser parser("Runs the scheduled convolution layer.", "");
-  args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
+  args::HelpFlag help(parser, "help", "Display this help menu", {'H', "help"});
 
   args::ValueFlag<std::string> schedule_algorithm(parser, "schedule algorithm", "The algorithm used to schedule the convolution. Legal values are auto, student, and default", {'s', "schedule"});
 


### PR DESCRIPTION
Currently -h is used as the short flag for both "help" and "height," and "help" takes precedence, so specifying the height leads to the program simply printing the usage guide and exiting. This PR changes "help" to -H to solve the conflict.